### PR TITLE
Belgian domains are always marked as available

### DIFF
--- a/fingerprint.go
+++ b/fingerprint.go
@@ -940,7 +940,7 @@ func fingerprints() map[string]string {
 		"xn--fiqs8s":               "No matching record",
 		"ax":                       "Invalid domain name",
 		"xn--90a3ac":               "Invalid domain name",
-		"be":                       "AVAILABLE",
+		"be":                       "Status: AVAILABLE",
 		"it":                       "AVAILABLE",
 		"by":                       "Object does not exist",
 		"nz":                       "220 Available",


### PR DESCRIPTION
.be domains always return AVAILABLE or NOT AVAILABLE. Available is always in the output, so this will always say that .BE domains are available.
This fixes this by requiring the Status: part as well.